### PR TITLE
Add GeometryService implementation

### DIFF
--- a/src/classes/share/META-INF/services/javax.media.j3d.GeometryService
+++ b/src/classes/share/META-INF/services/javax.media.j3d.GeometryService
@@ -1,0 +1,1 @@
+com.sun.j3d.utils.geometry.GeometryServiceImpl

--- a/src/classes/share/com/sun/j3d/utils/geometry/GeometryServiceImpl.java
+++ b/src/classes/share/com/sun/j3d/utils/geometry/GeometryServiceImpl.java
@@ -1,0 +1,38 @@
+
+package com.sun.j3d.utils.geometry;
+
+import java.util.ArrayList;
+
+import javax.media.j3d.GeometryArray;
+import javax.media.j3d.GeometryService;
+import javax.vecmath.Point3f;
+
+/**
+ * Default implementation of the {@link GeometryService} service interface.
+ */
+public class GeometryServiceImpl implements GeometryService {
+
+	@Override
+	public int triangulateIslands(final int[][] islandCounts,
+		final Point3f[][] outVerts, final int[] contourCounts,
+		final ArrayList<GeometryArray> triangData)
+	{
+		int vertOffset = 0;
+		final NormalGenerator ng = new NormalGenerator();
+		for (int i = 0; i < islandCounts.length; i++) {
+			contourCounts[0] = islandCounts[i].length;
+			final GeometryInfo gi = new GeometryInfo(GeometryInfo.POLYGON_ARRAY);
+			gi.setCoordinates(outVerts[i]);
+			gi.setStripCounts(islandCounts[i]);
+			gi.setContourCounts(contourCounts);
+			ng.generateNormals(gi);
+
+			final GeometryArray ga = gi.getGeometryArray(false, false, false);
+			vertOffset += ga.getVertexCount();
+
+			triangData.add(ga);
+		}
+		return vertOffset;
+	}
+
+}


### PR DESCRIPTION
This code was migrated from java3d-core's `Font3D` class, in order to address hharrison/java3d-core#17.

See also:
* gouessej/java3d-core#1 for the corresponding `GeometryService` interface
* hharrison/java3d-core#17 for the original issue.